### PR TITLE
Fix bug last day gas consumption

### DIFF
--- a/prep/load/econtrol-gas-consumption.r
+++ b/prep/load/econtrol-gas-consumption.r
@@ -14,6 +14,9 @@ d.agg = d.base[, .(
     value = Verwendungskomponenten
 )][, .(value = sum(value)/10^6), by = date][order(date)]
 
+# Latest day, i.e. the first day of the new month, contains only 5 h and is therefore wrong.
+d.agg = head(d.agg, -1)
+
 # Save
 fwrite(d.agg, file.path(g$d$o, 'consumption-gas.csv'))
 


### PR DESCRIPTION
Latest day, i.e. the first day of the new month, contains only 5 h and is therefore wrong. Therefore, the last aggregated daily value should be removed.